### PR TITLE
fix: 重复地址报错

### DIFF
--- a/app/lib/address-parse.js
+++ b/app/lib/address-parse.js
@@ -136,7 +136,7 @@ const AddressParse = (address, options) => {
         let name = ''
         if (~index) {
             name = copyDetail[index]
-        } else if (copyDetail[0].length <= nameMaxLength && /[\u4E00-\u9FA5]/.test(copyDetail[0])) {
+        } else if (copyDetail[0] && copyDetail[0].length <= nameMaxLength && /[\u4E00-\u9FA5]/.test(copyDetail[0])) {
             name = copyDetail[0]
         }
 


### PR DESCRIPTION
北京市北京市东城区北京市北京市东城区     重复地址会识别报错